### PR TITLE
Add osx-lib-say-rate to control speaking rate.

### DIFF
--- a/osx-lib.el
+++ b/osx-lib.el
@@ -40,7 +40,7 @@
   "Speech voice to use for osx-lib-say.  Nil/empty means default speech voice."
   :group 'osx-lib)
 
-(defcustom osx-lib-say-ratio nil
+(defcustom osx-lib-say-rate nil
   "Speech rate to be used, in words per minute. Average human speech occurs at a rate of 180 to 220 words per minute. Default depends on the voice used."
   :group 'osx-lib)
 
@@ -221,8 +221,8 @@ tell application \"System Events\"
 end tell
 "
 	   (osx-lib-escape message)
-	   (if (and osx-lib-say-ratio (numberp osx-lib-say-ratio))
-	       (format " speaking rate %d" osx-lib-say-ratio)
+	   (if (and osx-lib-say-rate (numberp osx-lib-say-rate))
+	       (format " speaking rate %d" osx-lib-say-rate)
 	     "")
 	   (if (and osx-lib-say-voice (stringp osx-lib-say-voice) (> (length (string-trim osx-lib-say-voice)) 1))
 	       (format " using \"%s\"" osx-lib-say-voice)

--- a/osx-lib.el
+++ b/osx-lib.el
@@ -40,6 +40,10 @@
   "Speech voice to use for osx-lib-say.  Nil/empty means default speech voice."
   :group 'osx-lib)
 
+(defcustom osx-lib-say-ratio nil
+  "Speech rate to be used, in words per minute. Average human speech occurs at a rate of 180 to 220 words per minute. Default depends on the voice used."
+  :group 'osx-lib)
+
 (defcustom osx-lib-debug-level nil
   "Debug level for osx-lib. Highier value implies more information."
   :group 'osx-lib)
@@ -213,10 +217,13 @@ end tell"
   (osx-lib-run-osascript
    (format "
 tell application \"System Events\"
-	say \"%s\"%s
+	say \"%s\"%s%s
 end tell
 "
 	   (osx-lib-escape message)
+	   (if (and osx-lib-say-ratio (numberp osx-lib-say-ratio))
+	       (format " speaking rate %d" osx-lib-say-ratio)
+	     "")
 	   (if (and osx-lib-say-voice (stringp osx-lib-say-voice) (> (length (string-trim osx-lib-say-voice)) 1))
 	       (format " using \"%s\"" osx-lib-say-voice)
 	     ""))))


### PR DESCRIPTION
Hi.
In this PR, `osx-lib-say-rate` is added in order to control the speaking rate when `say` command is called. It is very useful for org-mode user because the variable can be changed in source block dynamically. I can show you an example as follows:

``` lisp
#+BEGIN_SRC emacs-lisp :results silent
(setq osx-lib-say-rate 100) ;; make it slow
(setq yourscript "Hello World!")
(osx-lib-say yourscript)
#+END_SRC
```

Best,
Takaaki
