### PR TITLE
Add missing require eshell

### DIFF
--- a/osx-lib.el
+++ b/osx-lib.el
@@ -34,7 +34,6 @@
 ;;running apple script
 
 (require 'dired)
-(require 'eshell)
 (require 'subr-x)
 
 (defcustom osx-lib-say-voice nil
@@ -228,7 +227,7 @@ end tell
 (defun osx-open-url-at-point (url)
   "Open URL at point using default browser."
   (interactive (list (read-from-minibuffer "Please enter the url: " (thing-at-point 'url))))
-  (start-process "OsaScript" "*OsaScript*" "open" (eshell-escape-arg url)))
+  (start-process "OsaScript" "*OsaScript*" "open" (shell-quote-argument url)))
 
 ;;use mdfind instead of locate (setq locate-make-command-line #'osx-locate-make-command-line)
 (defun osx-locate-make-command-line (search-string)

--- a/osx-lib.el
+++ b/osx-lib.el
@@ -34,6 +34,7 @@
 ;;running apple script
 
 (require 'dired)
+(require 'eshell)
 (require 'subr-x)
 
 (defcustom osx-lib-say-voice nil
@@ -227,7 +228,7 @@ end tell
 (defun osx-open-url-at-point (url)
   "Open URL at point using default browser."
   (interactive (list (read-from-minibuffer "Please enter the url: " (thing-at-point 'url))))
-  (start-process "OsaScript" "*OsaScript*" "open" (shell-quote-argument url)))
+  (start-process "OsaScript" "*OsaScript*" "open" (eshell-escape-arg url)))
 
 ;;use mdfind instead of locate (setq locate-make-command-line #'osx-locate-make-command-line)
 (defun osx-locate-make-command-line (search-string)

--- a/osx-lib.el
+++ b/osx-lib.el
@@ -13,7 +13,7 @@
 ;;   3. Notification functions
 ;;      (osx-lib-notify2 "Emacs" "Text Editor")
 ;;   4. Copying to/from clipboard
-;;   5. Show the current file in Finder. Works with dired.
+;;   5. Show the current file in Finder.  Works with dired.
 ;;   6. Get/Set Sound volume
 ;;      (osx-lib-set-volume 25)
 ;;      (osx-lib-get-volume)
@@ -42,7 +42,7 @@
   :group 'osx-lib)
 
 (defcustom osx-lib-debug-level nil
-  "Debug level for osx-lib. Highier value implies more information."
+  "Debug level for osx-lib.  Highier value implies more information."
   :group 'osx-lib)
 
 (defun osx-lib-escape (str)

--- a/osx-lib.el
+++ b/osx-lib.el
@@ -34,6 +34,7 @@
 ;;running apple script
 
 (require 'dired)
+(require 'eshell)
 (require 'subr-x)
 
 (defcustom osx-lib-say-voice nil


### PR DESCRIPTION
A warning is displayed when at bytes compile.

```
In end of data:
osx-lib.el:281:1:Warning: the function `eshell-escape-arg' is not known to be
    defined.
```
